### PR TITLE
Prevent duplicate payment rows

### DIFF
--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -52,6 +52,7 @@ class NSC_Database {
             order_date DATETIME,
             payment_date DATETIME,
             PRIMARY KEY  (payment_id),
+            UNIQUE KEY user_id (user_id),
             FOREIGN KEY (user_id) REFERENCES {$wpdb->users}(ID)
         ) $charset_collate;";
         

--- a/includes/class-payment-handler.php
+++ b/includes/class-payment-handler.php
@@ -262,17 +262,37 @@ class NSC_Payment_Handler {
                 ],
                 ['%d', '%s', '%s', '%s', '%s', '%s', '%s']
             );
-            
-            // Create payment record
-            $wpdb->insert(
-                "{$wpdb->prefix}nsc_payments",
-                [
-                    'user_id' => $user_id,
-                    'status' => 'pending',
-                    'order_date' => current_time('mysql')
-                ],
-                ['%d', '%s', '%s']
+
+            // Create or update payment record
+            $existing_payment = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT payment_id FROM {$wpdb->prefix}nsc_payments WHERE user_id = %d",
+                    $user_id
+                )
             );
+
+            if ($existing_payment) {
+                $wpdb->update(
+                    "{$wpdb->prefix}nsc_payments",
+                    [
+                        'status' => 'pending',
+                        'order_date' => current_time('mysql')
+                    ],
+                    ['payment_id' => $existing_payment],
+                    ['%s', '%s'],
+                    ['%d']
+                );
+            } else {
+                $wpdb->insert(
+                    "{$wpdb->prefix}nsc_payments",
+                    [
+                        'user_id' => $user_id,
+                        'status' => 'pending',
+                        'order_date' => current_time('mysql')
+                    ],
+                    ['%d', '%s', '%s']
+                );
+            }
             
             // Auto-login user and redirect
             wp_set_auth_cookie($user_id, true);

--- a/nsc-fluentforms-integration.php
+++ b/nsc-fluentforms-integration.php
@@ -261,17 +261,37 @@ class NSC_FluentForms_Integration {
                 ],
                 ['%d', '%s', '%s', '%s', '%s', '%s', '%s']
             );
-            
-            // Create payment record
-            $wpdb->insert(
-                "{$wpdb->prefix}nsc_payments",
-                [
-                    'user_id' => $user_id,
-                    'status' => 'pending',
-                    'order_date' => current_time('mysql')
-                ],
-                ['%d', '%s', '%s']
+
+            // Create or update payment record
+            $existing_payment = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT payment_id FROM {$wpdb->prefix}nsc_payments WHERE user_id = %d",
+                    $user_id
+                )
             );
+
+            if ($existing_payment) {
+                $wpdb->update(
+                    "{$wpdb->prefix}nsc_payments",
+                    [
+                        'status' => 'pending',
+                        'order_date' => current_time('mysql')
+                    ],
+                    ['payment_id' => $existing_payment],
+                    ['%s', '%s'],
+                    ['%d']
+                );
+            } else {
+                $wpdb->insert(
+                    "{$wpdb->prefix}nsc_payments",
+                    [
+                        'user_id' => $user_id,
+                        'status' => 'pending',
+                        'order_date' => current_time('mysql')
+                    ],
+                    ['%d', '%s', '%s']
+                );
+            }
             
             // Store the user ID in a transient for the redirect handler
             set_transient('nsc_registered_user_' . $entry_id, $user_id, 5 * MINUTE_IN_SECONDS);

--- a/scripts/cleanup-duplicate-payments.php
+++ b/scripts/cleanup-duplicate-payments.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Cleanup script for duplicate nsc_payments rows.
+ *
+ * Removes older payment rows keeping the most recent record per user.
+ *
+ * Usage:
+ *   wp eval-file scripts/cleanup-duplicate-payments.php
+ */
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+    exit( "This script must be run from WP-CLI.\n" );
+}
+
+global $wpdb;
+$table = "{$wpdb->prefix}nsc_payments";
+
+$deleted = $wpdb->query( "
+    DELETE p1 FROM $table p1
+    INNER JOIN $table p2
+        ON p1.user_id = p2.user_id
+        AND p1.payment_id < p2.payment_id
+" );
+
+WP_CLI::success( sprintf( 'Removed %d duplicate payment rows.', $deleted ) );
+


### PR DESCRIPTION
## Summary
- avoid inserting duplicate payment rows on registration
- enforce unique payments per user and provide cleanup script

## Testing
- `php -l includes/class-payment-handler.php`
- `php -l nsc-fluentforms-integration.php`
- `php -l includes/class-database.php`
- `php -l scripts/cleanup-duplicate-payments.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6aaac0a48325ae13e5cef05bef52