### PR TITLE
Add search filters to participants and payments admin pages

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -183,10 +183,11 @@ class NSC_Admin {
         $per_page = 20;
         $current_page = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
         $offset = ($current_page - 1) * $per_page;
-        
+
         // Filter settings
         $category = isset($_GET['category']) ? sanitize_text_field($_GET['category']) : '';
         $payment_status = isset($_GET['payment_status']) ? sanitize_text_field($_GET['payment_status']) : '';
+        $search = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
         
         // Build WHERE clause
         $where_conditions = array();
@@ -203,6 +204,14 @@ class NSC_Admin {
             } else {
                 $where_conditions[] = "(pm.status IS NULL OR pm.status != 'paid')";
             }
+        }
+
+        if (!empty($search)) {
+            $like = '%' . $wpdb->esc_like($search) . '%';
+            $where_conditions[] = "(p.first_name LIKE %s OR p.last_name LIKE %s OR u.user_email LIKE %s)";
+            $where_params[] = $like;
+            $where_params[] = $like;
+            $where_params[] = $like;
         }
         
         $where_clause = !empty($where_conditions) ? 'WHERE ' . implode(' AND ', $where_conditions) : '';
@@ -257,9 +266,10 @@ class NSC_Admin {
         $per_page = 20;
         $current_page = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
         $offset = ($current_page - 1) * $per_page;
-        
+
         // Filter settings
         $status_filter = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
+        $search = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
         
         // Build WHERE clause
         $where_conditions = array();
@@ -268,6 +278,15 @@ class NSC_Admin {
         if (!empty($status_filter)) {
             $where_conditions[] = "pm.status = %s";
             $where_params[] = $status_filter;
+        }
+
+        if (!empty($search)) {
+            $like = '%' . $wpdb->esc_like($search) . '%';
+            $where_conditions[] = "(p.first_name LIKE %s OR p.last_name LIKE %s OR u.user_email LIKE %s OR CAST(pm.payment_id AS CHAR) LIKE %s)";
+            $where_params[] = $like;
+            $where_params[] = $like;
+            $where_params[] = $like;
+            $where_params[] = $like;
         }
         
         $where_clause = !empty($where_conditions) ? 'WHERE ' . implode(' AND ', $where_conditions) : '';

--- a/templates/admin/participants.php
+++ b/templates/admin/participants.php
@@ -3,6 +3,7 @@
  * Admin Participants Template
  */
 if (!defined('ABSPATH')) exit;
+$search = isset($search) ? $search : '';
 ?>
 
 <div class="wrap">
@@ -26,6 +27,7 @@ if (!defined('ABSPATH')) exit;
                     <option value="paid" <?php selected($payment_status, 'paid'); ?>><?php esc_html_e('Paid', 'nsc-core'); ?></option>
                     <option value="not_paid" <?php selected($payment_status, 'not_paid'); ?>><?php esc_html_e('Not Paid', 'nsc-core'); ?></option>
                 </select>
+                <input type="search" name="s" value="<?php echo esc_attr($search); ?>" placeholder="<?php esc_attr_e('Search participants', 'nsc-core'); ?>">
                 <input type="submit" class="button" value="<?php esc_attr_e('Filter', 'nsc-core'); ?>">
             </form>
         </div>

--- a/templates/admin/payments.php
+++ b/templates/admin/payments.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) exit;
 
 // Get the current filter value (if any)
 $current_status = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
+$search = isset($search) ? $search : '';
 
 // Handle "Mark as Paid" action
 if (isset($_GET['action']) && $_GET['action'] === 'mark_as_paid' && isset($_GET['payment_id']) && isset($_GET['_wpnonce'])) {
@@ -76,6 +77,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'mark_as_paid' && isset($_GET[
                     <option value="failed" <?php selected($current_status, 'failed'); ?>><?php esc_html_e('Failed', 'nsc-core'); ?></option>
                     <option value="cancelled" <?php selected($current_status, 'cancelled'); ?>><?php esc_html_e('Cancelled', 'nsc-core'); ?></option>
                 </select>
+                <input type="search" name="s" value="<?php echo esc_attr($search); ?>" placeholder="<?php esc_attr_e('Search payments', 'nsc-core'); ?>">
                 <input type="submit" class="button" value="<?php esc_attr_e('Filter', 'nsc-core'); ?>">
             </form>
         </div>


### PR DESCRIPTION
## Summary
- add search parameter handling for participant and payment listings
- include search inputs on admin templates for participants and payments

## Testing
- `php -l includes/class-admin.php`
- `php -l templates/admin/participants.php`
- `php -l templates/admin/payments.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad715b91e883259ff30c28743738c8