### PR TITLE
Add CSV export for video uploads

### DIFF
--- a/templates/admin/uploads.php
+++ b/templates/admin/uploads.php
@@ -30,6 +30,8 @@ if (!defined('ABSPATH')) exit;
                 </select>
                 <input type="submit" class="button" value="<?php esc_attr_e('Filter', 'nsc-core'); ?>">
             </form>
+            <?php $export_url = add_query_arg(array('export' => 'csv')); ?>
+            <a href="<?php echo esc_url($export_url); ?>" class="button"><?php esc_html_e('Export as CSV', 'nsc-core'); ?></a>
         </div>
         <div class="tablenav-pages">
             <?php if ($total_pages > 1): ?>


### PR DESCRIPTION
## Summary
- enable admin CSV export for video uploads with participant and contact info
- add export button to uploads admin page

## Testing
- `php -l includes/class-admin.php`
- `php -l templates/admin/uploads.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad72331fb48325a34dce0f5bf37213